### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/buildroot/package/slirp/Config.in
+++ b/buildroot/package/slirp/Config.in
@@ -15,7 +15,7 @@ config BR2_PACKAGE_SLIRP
 	  NOTE:
 	  This package has some history of a unique kind:
 	    - originally developped as 'slirp' by Danny Gasparovski, and
-	      seemingly abandonned (developper /disapeared/)
+	      seemingly abandoned (developper /disapeared/)
 	    - then re-maintained at sourceforge by "Kelly", up to some
 	      time around 2009: http://slirp.sourceforge.net/
 	    - during that period, QEMU (Fabrice BELLARD) forked the code


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

If you decide to close this pull request, pleace specify why before doing so.

With kind regards,
TheTypoMaster
